### PR TITLE
Add option to automatically determine domain.

### DIFF
--- a/tasks/i18next_conv.js
+++ b/tasks/i18next_conv.js
@@ -15,6 +15,10 @@ module.exports = function(grunt) {
 
   grunt.registerMultiTask('i18next_conv', 'Convert files using i18next-conv.', function() {
     // Merge task-specific and/or target-specific options with these defaults.
+    var options = this.options({
+        domainCallback: false,
+    });
+
     var filecount = 0;
     var done = this.async();
     // Iterate over all specified file groups.
@@ -28,8 +32,13 @@ module.exports = function(grunt) {
           return false;
         } else {
           if(!f.domain) {
-            grunt.log.error('Domain must be specified for ' + filepath);
-            return false;
+               if( options.domainCallback && 'function' == typeof options.domainCallback ){
+                    f.domain = options.domainCallback( f );
+               }
+               if( !f.domain ){
+                    grunt.log.error('Domain must be specified for ' + filepath);
+                    return false;
+               }
           }
           return true;
         }


### PR DESCRIPTION
Hi @aaronlecompte 

Thanks for this plug-in. I wondered if you'd consider this PR. The context is that I have (potentially) a lot of files of a known format: `<fixed-known-string>-<locale-code>.mo`, rather than manually add (and maintain) each locale, which this PR I can I automatically extract the locale code and use that.

The PR exposes an option `domainCallback` that allows me to something like:

```
i18next_conv: {
    files:{
        src: 'languages/*.mo',
        ext: '.json',
        expand: true,
    },
    options:{
        domainCallback: function( f ){
            var path = f.src[0].substr(0, f.src[0].lastIndexOf('.')); //get rid of everything after last .

            //Get locale from path
            var parts = path.split('-');
            parts.shift();
            var locale = parts.join('-');
            return locale;
    }
    }
}
```

This means the `Gruntfile.js` won't have to be edited each time `.mo` file is added.
